### PR TITLE
fix(diff): Prevent segfaults in bestCandidates

### DIFF
--- a/deepdiff.go
+++ b/deepdiff.go
@@ -187,19 +187,33 @@ func matchNodes(n1, n2 node) {
 }
 
 func bestCandidate(t1Candidates []node, n2 node, t2Weight int) {
+	if n2.Parent() == nil {
+		return
+	}
+
+	// Copy the candidate list so that this slice can be modified
+	nodeList := make([]node, len(t1Candidates))
+	copy(nodeList, t1Candidates)
+
 	maxDist := 1 + float32(n2.Weight())/float32(t2Weight)
 	dist := 1 + float32(n2.Parent().Weight()-n2.Weight())/float32(t2Weight)
 	n2 = n2.Parent()
 
 	for dist < maxDist {
-		for i, can := range t1Candidates {
+		for i, can := range nodeList {
+			// Some nodes are replaced with their parents, which may result in
+			// a nil pointer once we reach the root
+			if can == nil {
+				continue
+			}
 			if cp := can.Parent(); cp != nil {
 				if n2.Addr().Eq(cp.Addr()) {
 					matchNodes(cp, n2)
 					return
 				}
 			}
-			t1Candidates[i] = can.Parent()
+			// Move to the candidates parent, which may result in a nil pointer
+			nodeList[i] = can.Parent()
 		}
 		if n2.Parent() == nil {
 			break

--- a/tree.go
+++ b/tree.go
@@ -190,8 +190,8 @@ func (d *diff) prepTrees(ctx context.Context) (t1, t2 node, t1nodes map[string][
 		wg                sync.WaitGroup
 		t1nodesCh         = make(chan node)
 		t2nodesCh         = make(chan node)
-		t1Nodes, t1Weight int
-		t2Nodes, t2Weight int
+		t1Count, t1Weight int
+		t2Count, t2Weight int
 	)
 
 	t1nodes = map[string][]node{}
@@ -201,7 +201,7 @@ func (d *diff) prepTrees(ctx context.Context) (t1, t2 node, t1nodes map[string][
 		for n := range nodes {
 			key := hashStr(n.Hash())
 			t1nodes[key] = append(t1nodes[key], n)
-			t1Nodes++
+			t1Count++
 			t1Weight += n.Weight()
 		}
 		wg.Done()
@@ -214,7 +214,7 @@ func (d *diff) prepTrees(ctx context.Context) (t1, t2 node, t1nodes map[string][
 	go func(nodes <-chan node) {
 		for n := range nodes {
 			// do nothing
-			t2Nodes++
+			t2Count++
 			t2Weight += n.Weight()
 		}
 		wg.Done()
@@ -227,9 +227,9 @@ func (d *diff) prepTrees(ctx context.Context) (t1, t2 node, t1nodes map[string][
 	wg.Wait()
 
 	if d.stats != nil {
-		d.stats.Left = t1Nodes
+		d.stats.Left = t1Count
 		d.stats.LeftWeight = t1Weight
-		d.stats.Right = t2Nodes
+		d.stats.Right = t2Count
 		d.stats.RightWeight = t2Weight
 	}
 	return


### PR DESCRIPTION
BestCandidates compares a list of candidate nodes, taken from the hashed nodes from d1, against a single node n2 from d2. During the comparison, nodes will be promoted to their parents if they don't immediately match. This can cause nil pointers to appear in the candidate list, and since the candidate list is aliased to the value of the t1Nodes map, over time multiple calls to BestCandidates may result in dereferencing a nil pointer, causing a segfault.

Instead, copy the candidate list, so it's safe to modify. Also, check if the candidate node is nil before trying to deref it. Note that this does not introduce the possibility of an infinite loop, since n2 is always promoted to its parent, which means it will eventually hit the root, and then break the loop.

I don't totally understand this function, so I can't write a unit test validating this behavior is improved. Would like to come back to deepdiff later and reevaluate its core algorithm.